### PR TITLE
Compile programs in serial using a queue channel

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -131,7 +131,7 @@ impl ProgramBuilder {
 }
 /// Get the name of the first .wasm file we find in the target directory
 async fn get_binary_filename(binary_dir: PathBuf) -> Result<PathBuf, AppError> {
-    let mut dir_contents = read_dir(binary_dir).await.unwrap();
+    let mut dir_contents = read_dir(binary_dir).await?;
     while let Some(entry) = dir_contents.next_entry().await? {
         if let Some(extension) = entry.path().extension() {
             if extension.to_str() == Some("wasm") {


### PR DESCRIPTION
Currently if several people request to build a program at the same time, they will be run concurrently, potentially overloading the server. This PR will put them into a queue and process them in serial. This is still vulnerable to DoS attacks, as all requests will eventually by processed.  But at least the server should stay running.