### PR TITLE
Add example client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -489,6 +490,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1102,6 +1115,12 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2173,10 +2192,12 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -3495,6 +3516,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wasmparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,5 @@ futures = "0.3.30"
 serde = "1.0.202"
 
 [dev-dependencies]
-clap = "4.5.4"
-reqwest = "0.12.4"
+clap = { version = "4.5.4", features = ["derive"] }
+reqwest = { version = "0.12.4", features = ["stream"] }

--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ Example reponse:
 }
 ```
 
+## Example client
+
+There is also a simple command-line client given as an example. For usage information run:
+
+```bash
+cargo run --example client help
+```
+
 ## Running the server
 
 ### Requirements:

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,4 +1,104 @@
+use clap::{Parser, Subcommand};
+use futures::StreamExt;
+use program_metadata_http_service::build::BuildResponse;
+use std::{fs::File, io::Write};
+
+#[derive(Parser, Debug, Clone)]
+#[clap(version, about = "CLI tool for testing program-metadata-http-service")]
+struct Cli {
+    #[clap(subcommand)]
+    command: CliCommand,
+    /// The server to use - defaults to http://localhost:3000
+    #[arg(short, long)]
+    server_endpoint: Option<String>,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+enum CliCommand {
+    /// Build a program
+    Build {
+        /// Url to a git repo containing the program to build
+        git_url: String,
+    },
+    /// List hashes of all programs in the db
+    List,
+    /// Display metadata about a given program
+    Program {
+        /// Hex encoded hash of a program
+        hash: String,
+    },
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    let endpoint_addr = cli.server_endpoint.unwrap_or_else(|| {
+        std::env::var("PROGRAM_METADATA_SERVICE_ENDPOINT")
+            .unwrap_or("http://localhost:3000".to_string())
+    });
+
+    match cli.command {
+        CliCommand::Build { git_url } => {
+            let client = reqwest::Client::new();
+            let res = client
+                .post(format!("{}/add-program-git", endpoint_addr))
+                .body(git_url)
+                .send()
+                .await?;
+
+            if res.status() == 200 {
+                let mut bytes_stream = res.bytes_stream();
+                let mut chunks = Vec::new();
+                while let Some(Ok(chunk)) = bytes_stream.next().await {
+                    // println!("chunk {}", String::from_utf8(chunk.to_vec()).unwrap());
+
+                    chunks.extend_from_slice(&chunk);
+                    let result_response: Result<BuildResponse, serde_json::Error> =
+                        serde_json::from_slice(&chunks[..]);
+
+                    if let Ok(response) = result_response {
+                        chunks.clear();
+                        match response {
+                            BuildResponse::StdOut(output) => {
+                                print!("{}", output);
+                            }
+                            BuildResponse::StdErr(output) => {
+                                eprint!("{}", output);
+                            }
+                            BuildResponse::Success {
+                                hash,
+                                binary,
+                                binary_filename,
+                            } => {
+                                println!("Success {:?}", hash);
+                                let mut file = File::create(&binary_filename)?;
+                                file.write_all(&binary)?;
+                                println!("Writen {} bytes to {}", binary.len(), binary_filename);
+                            }
+                        }
+                    }
+                }
+            } else {
+                println!("Failed to build {}", res.text().await?);
+            }
+        }
+        CliCommand::List => {
+            let body = reqwest::get(format!("{}/programs", endpoint_addr))
+                .await?
+                .text()
+                .await?;
+
+            println!("{body}");
+        }
+        CliCommand::Program { hash } => {
+            let body = reqwest::get(format!("{}/program/{}", endpoint_addr, hash))
+                .await?
+                .text()
+                .await?;
+
+            println!("{body}");
+        }
+    }
     Ok(())
 }


### PR DESCRIPTION
This adds a simple CLI example to show using the service programmatically.  It can serve as the basis for integrating this into the programs CLI build tool. 